### PR TITLE
Add `upload`/`download` convenience methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ slog = "2"
 
 [dev-dependencies]
 slog-term = "2"
+tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,23 @@
 
 use educe::Educe;
 use failure::{bail, format_err};
-use failure::{Error, ResultExt};
+use failure::{Error, Fail, ResultExt};
 use slog;
 use slog::{trace, warn};
 use ssh2;
+use std::fs::File;
+use std::io;
 use std::net::{SocketAddr, TcpStream};
 use std::path::Path;
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[derive(Debug, Fail)]
+#[fail(display = "error transferring file {}: {}", file, msg)]
+struct FileTransferFailure {
+    file: String,
+    msg: String,
+}
 
 /// An established SSH session.
 ///
@@ -173,10 +182,127 @@ impl Session {
         }
     }
 
+    /// Copy a file from the local machine to the remote host.
+    ///
+    /// Both remote and local paths can be absolute or relative.
+    ///
+    /// ```rust,no_run
+    /// # use sessh::Session;
+    /// # use failure::Error;
+    /// # fn upload_artifact(ssh: Session) -> Result<(), Error> {
+    ///     use std::path::Path;
+    ///     ssh.upload(
+    ///         Path::new("build/output.tar.gz"), // on the local machine
+    ///         Path::new("/srv/output.tar.gz"), // on the remote machine
+    ///     )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn upload(&self, local_src: &Path, remote_dst: &Path) -> Result<(), Error> {
+        let sftp = self.ssh.sftp().map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create ssh channel while uploading file '{}'",
+                local_src.display()
+            ))
+        })?;
+        let mut dst_file = sftp.create(&remote_dst).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create file '{}' on remote host",
+                remote_dst.display()
+            ))
+        })?;
+
+        let mut src_file = File::open(&local_src).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to open file '{}' on local machine",
+                local_src.display()
+            ))
+        })?;
+
+        let copied = io::copy(&mut src_file, &mut dst_file)
+            .map_err(Error::from)
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to upload file '{}' to remote host",
+                    local_src.display()
+                ))
+            })?;
+
+        let expected = src_file.metadata()?.len();
+        if copied < expected {
+            Err(FileTransferFailure {
+                file: local_src.display().to_string(),
+                msg: format!("only copied {}/{} bytes", copied, expected),
+            })?
+        }
+
+        Ok(())
+    }
+
     /// Issue the given command and return the command's stdout and stderr.
     pub fn cmd(&self, cmd: &str) -> Result<(String, String), Error> {
         let (out, err) = self.cmd_raw(cmd)?;
         Ok((String::from_utf8(out)?, String::from_utf8(err)?))
+    }
+
+    /// Copy a file from the remote host to the local machine.
+    ///
+    /// Both remote and local paths can be absolute or relative.
+    ///
+    /// ```rust,no_run
+    /// # use sessh::Session;
+    /// # use failure::Error;
+    /// # fn download_hostname(ssh: Session) -> Result<(), Error> {
+    ///     use std::path::Path;
+    ///     ssh.download(
+    ///         Path::new("/etc/hostname"), // on the remote machine
+    ///         Path::new("remote-hostname"), // on the local machine
+    ///     )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn download(&self, remote_src: &Path, local_dst: &Path) -> Result<(), Error> {
+        let sftp = self.ssh.sftp().map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create ssh channel while downloading file '{}'",
+                remote_src.display()
+            ))
+        })?;
+        let mut src_file = sftp.open(&remote_src).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to open file '{}' on remote host",
+                remote_src.display()
+            ))
+        })?;
+
+        let mut dst_file = File::create(&local_dst).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create file '{}' on local machine",
+                local_dst.display()
+            ))
+        })?;
+
+        let copied = io::copy(&mut src_file, &mut dst_file)
+            .map_err(Error::from)
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to download file '{}' from remote host",
+                    remote_src.display()
+                ))
+            })?;
+
+        // `stat().size` can be None. A little odd but not worth failing if
+        // everything else seemed to succeed.
+        if let Some(expected) = src_file.stat()?.size {
+            if copied < expected {
+                Err(FileTransferFailure {
+                    file: remote_src.display().to_string(),
+                    msg: format!("only copied {}/{} bytes", copied, expected),
+                })?
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -199,6 +325,8 @@ mod tests {
     use super::Session;
     use failure::Error;
     use slog::o;
+    use std::fs::File;
+    use std::io::Write;
 
     pub fn test_logger() -> slog::Logger {
         use slog::Drain;
@@ -207,20 +335,82 @@ mod tests {
         slog::Logger::root(drain, o!())
     }
 
+    fn get_curr_user() -> Result<String, Error> {
+        let curr_user = std::process::Command::new("whoami").output()?.stdout;
+        let curr_user = String::from_utf8(curr_user)?;
+        Ok(curr_user.split_whitespace().next().unwrap().to_string())
+    }
+
     #[test]
     #[ignore] // ignore by default since there is no ssh-agent in travis ci
     fn localhost() -> Result<(), Error> {
         let log = test_logger();
 
-        let curr_user = std::process::Command::new("whoami").output()?.stdout;
-        let curr_user = String::from_utf8(curr_user)?;
-        let curr_user = curr_user.split_whitespace().next().unwrap();
+        let curr_user = get_curr_user()?;
         slog::trace!(log, "current user"; "user" => &curr_user);
-        let s = Session::connect(&log, curr_user, "127.0.0.1:22".parse()?, None, None)?;
+        let s = Session::connect(&log, &curr_user, "127.0.0.1:22".parse()?, None, None)?;
         slog::trace!(log, "connected to localhost");
         let (ssh_user, _) = s.cmd("whoami")?;
         let ssh_user = ssh_user.split_whitespace().next().unwrap();
         assert_eq!(ssh_user, curr_user);
+        Ok(())
+    }
+
+    /// Tests uploading a file via SSH-to-localhost (using a running SSH agent).
+    #[test]
+    #[ignore] // ignore by default since there is no ssh-agent in travis ci
+    fn localhost_upload() -> Result<(), Error> {
+        const CONTENTS: &'static str = "hello";
+
+        let log = test_logger();
+
+        let temp_dir = tempfile::TempDir::new()?;
+
+        let local_file = temp_dir.path().join("source");
+        {
+            let file = File::create(&local_file)?;
+            write!(&file, "{}", CONTENTS)?;
+        }
+
+        let curr_user = get_curr_user()?;
+        let s = Session::connect(&log, &curr_user, "127.0.0.1:22".parse()?, None, None)?;
+        slog::trace!(log, "current user"; "user" => &curr_user);
+
+        // we're SSHing to localhost, so we can use the same temp dir!
+        let remote_file = temp_dir.path().join("dest");
+        s.upload(&local_file, &remote_file)?;
+        let (ssh_contents, _) = s.cmd(&format!("cat {}", remote_file.to_string_lossy()))?;
+        let ssh_contents = ssh_contents.split_whitespace().next().unwrap();
+        assert_eq!(ssh_contents, CONTENTS);
+        Ok(())
+    }
+
+    /// Tests downloading a file via SSH-to-localhost (using a running SSH agent).
+    #[test]
+    #[ignore] // ignore by default since there is no ssh-agent in travis ci
+    fn localhost_download() -> Result<(), Error> {
+        const CONTENTS: &'static str = "hello";
+
+        let log = test_logger();
+
+        let temp_dir = tempfile::TempDir::new()?;
+
+        let remote_file = temp_dir.path().join("source");
+        {
+            let file = File::create(&remote_file)?;
+            write!(&file, "{}", CONTENTS)?;
+        }
+
+        let curr_user = get_curr_user()?;
+        let s = Session::connect(&log, &curr_user, "127.0.0.1:22".parse()?, None, None)?;
+        slog::trace!(log, "current user"; "user" => &curr_user);
+
+        // we're SSHing to localhost, so we can use the same temp dir!
+        let local_file = temp_dir.path().join("dest");
+        s.download(&remote_file, &local_file)?;
+        let (ssh_contents, _) = s.cmd(&format!("cat {}", remote_file.to_string_lossy()))?;
+        let ssh_contents = ssh_contents.split_whitespace().next().unwrap();
+        assert_eq!(ssh_contents, CONTENTS);
         Ok(())
     }
 }


### PR DESCRIPTION
As discussed in [jonhoo/tsunami#24](https://github.com/jonhoo/tsunami/pull/24).
I'm happy to implement using the `scp_recv`, `scp_send` methods if there's any preference to use the SCP interface instead of the SFTP interface.

I saw the tests run, then added `#[ignore]`. (One hack I've used with Travis is gating the tests on a Crate feature that's not included by default. Then `cargo test --all-features` runs it, but Travis is blissfully unaware.)